### PR TITLE
Fix issue where index property did not exist

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -41,7 +41,7 @@ local function debug(...)
 end
 
 local function getID(entity)
-    return entity.is_player() and (-entity.index - 1) or entity.unit_number
+    return entity.is_player() and entity.index and (-entity.index - 1) or entity.unit_number
 end
 
 local function getPlayer(event)


### PR DESCRIPTION
This can happen in the Krastorio 2 + Space Exploration mod pack (possibly just with Induction Charging and Space Exploration), when landing the space ship on another planet.